### PR TITLE
Update Bevy details for meetings

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -42,16 +42,14 @@ We will propose new assets that guide adopters of cloud native technology, in li
 
 - Slack channel: slack.cncf.io, `#cartografos-wg`
 
-- Please sign up to the CNCF’s community platform at <https://community.cncf.io/> and then join <https://community.cncf.io/cncf-cartografos-working-group/>
-
 - To participate in the working group, please sign up to the CNCF’s community platform at <https://community.cncf.io/> and  join <https://community.cncf.io/cncf-cartografos-working-group/>
 
-- We hold regular community meetings every second Tuesday at 6PM London, UK, and we encourage you to join.  They too are listed on the same page:
+- We hold regular community meetings every second Tuesday at 1PM US/Eastern, and we encourage you to join.  The meetings are listed on the same page and you can simply RSVP to each event:
 <https://community.cncf.io/cncf-cartografos-working-group/>
 
 ## Meeting Schedule
 
-Every second Tuesday at 6PM-7PM London, UK.
+Every second Tuesday at 1PM-2PM US/Eastern
 
 The meeting cadence due for review after KubeCon North America 2021
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ We want to educate and inform users with effective and practical guidance to hel
 
 We work to engage with CNCF projects at sandbox, incubating, and graduated level to ensure effective and accurate representation within assets, as well as CNCF Technical Advisory Groups. We also provide a vendor neutral forum for validation, discussion and feedback.
 As you get started, you are in the best position to give us feedback on areas where the working group needs help. This includes:
+
 - Gaps in our documentation
 - Working to define new artifacts
 - Engaging with TAGs and SIGs within the CNCF and its projects
@@ -42,11 +43,9 @@ Not everything happens through a GitHub pull request. Please come to our meeting
 
 ## Come to meetings
 
-Everyone is welcome to come to any of our meetings.
+Everyone is welcome to come to any of our meetings. We hold regular community meetings every second Tuesday at 6PM US/Eastern time
 
-You may need to join the Cartografos Working Group community on community.cncf.io to get access to the meeting - simply click on "Join" within <https://community.cncf.io/cncf-cartografos-working-group/>
-
-We hold regular community meetings every second Tuesday at 6PM London, UK, and we encourage you to join. You can join simply by RSVP'ing to the event on community.cncf.io.
+You will need to join the Cartografos Working Group community on <https://community.cncf.io> then simply RSVP within the meeting instance at <https://community.cncf.io/cncf-cartografos-working-group/>
 
 The first time you come, introducing yourself is more than enough. Over time, we hope that you feel comfortable voicing your opinions, giving feedback on others’ ideas, and even sharing your own ideas, and experiences.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As these are living documents, we welcome your feed back and invite you to submi
 
 Please sign up to the CNCF’s community platform at <https://community.cncf.io/> and  join <https://community.cncf.io/cncf-cartografos-working-group/>
 
-We hold regular community meetings every second Tuesday at 6PM London, UK, and we encourage you to join.  They too are listed on the same page:
+We hold regular community meetings every second Tuesday at 1PM US/Eastern, and we encourage you to join.  They are listed on the same page and you can simply RSVP to the meeting instance:
 <https://community.cncf.io/cncf-cartografos-working-group/>
 
 Please also join our our CNCF Slack channel, `#cartografos-wg`


### PR DESCRIPTION
* Update time zone to US/Eastern from London, UK to avoid confusion with GMT/UTC and BST.
* Minor rewording for clarity on how to join meetings
Fixes #6