### PR TITLE
Try to explicitly set HUGO_ENV in netlify.toml

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -2,3 +2,9 @@
 [build.environment]
 HUGO_VERSION = "0.104.3"
 GO_VERSION = "1.19.2"
+
+[context.production.environment]
+HUGO_ENV = "production"
+
+[context.deploy-preview.environment]
+HUGO_ENV = "preview"


### PR DESCRIPTION
To address [this issue](https://github.com/cncf/cncf.io/issues/824), we want to explicitly set `HUGO_ENV` so that it only is "production" on the production instance of the site. This is important so we don't run Google Analytics on preview or dev instances.